### PR TITLE
Convert `;` to `'`

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,7 +8,7 @@ head
 
   title = page_title
   
-  meta name="viewport" content="width=device-width; initial-scale=1, maximum-scale=1"
+  meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"
   
   / link rel="apple-touch-icon" href="touch-icon-ipad.png"
   / link rel="apple-touch-icon" sizes="76x76" href="touch-icon-ipad.png"


### PR DESCRIPTION
Remove warning:

Error parsing a meta element's content: ';' is not a valid key-value pair separator. Please use ',' instead.